### PR TITLE
Create yamlinc.json

### DIFF
--- a/data/yamlinc.json
+++ b/data/yamlinc.json
@@ -1,0 +1,11 @@
+{
+  "name": "Yamlinc",
+  "repository_platform": "github",
+  "repository_url": "https://www.github.com/javanile/yamlinc",
+  "site_url": "https://www.javanile.org",
+  "type": "tool",
+  "license": "MIT",
+  "tags": [
+    "yaml", "openapi"
+  ]
+}


### PR DESCRIPTION
Added Yamlinc: 

A tool for compose multiple YAML files into one with $include tag. Split Swagger/OpenAPI into multiple YAML files.