### PR TITLE
Fix: typo on repository link

### DIFF
--- a/.github/PULL_REQUEST.md
+++ b/.github/PULL_REQUEST.md
@@ -1,6 +1,6 @@
 ## PR Checklist
 
-- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/Italia-Open-Source/awesome-italia-opensource/blob/main/CONTRIBUTING.md#pull-requests).
-- [ ] I have read the [Code of conduct](https://github.com/Italia-Open-Source/awesome-italia-opensource/blob/main/CODE_OF_CONDUCT.md).
+- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/italia-opensource/awesome-italia-opensource/blob/main/CONTRIBUTING.md#pull-requests).
+- [ ] I have read the [Code of conduct](https://github.com/italia-opensource/awesome-italia-opensource/blob/main/CODE_OF_CONDUCT.md).
 - [ ] **If this is an added new project**: I created the PROJECT_NAME.json file in the /data folder and complied with the required fields
 - [ ] **If this is related a issues/PR**: I documented and tested the code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Code of Conduct
 
-Please read [the full text](https://github.com/Italia-Open-Source/awesome-italia-opensource/blob/main/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+Please read [the full text](https://github.com/italia-opensource/awesome-italia-opensource/blob/main/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
 ### Join our Community
 

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ The repository intends to give visibility to open source projects and stimulate 
 
 ### Contributors
 
-<a href="https://github.com/Italia-Open-Source/awesome-italia-opensource/graphs/contributors"> <img src="https://contrib.rocks/image?repo=Italia-Open-Source/awesome-italia-opensource" /> </a> Made with [contrib.rocks](https://contrib.rocks).
+<a href="https://github.com/Italia-OpenSource/awesome-italia-opensource/graphs/contributors"> <img src="https://contrib.rocks/image?repo=Italia-Open-Source/awesome-italia-opensource" /> </a> Made with [contrib.rocks](https://contrib.rocks).

--- a/cli.py
+++ b/cli.py
@@ -227,7 +227,7 @@ def build(data):
         doc.add_header('Contributors', level=3)
 
         doc.add_paragraph("""
-                <a href="https://github.com/Italia-Open-Source/awesome-italia-opensource/graphs/contributors">
+                <a href="https://github.com/italia-opensource/awesome-italia-opensource/graphs/contributors">
                     <img src="https://contrib.rocks/image?repo=Italia-Open-Source/awesome-italia-opensource" />
                 </a>
                 Made with [contrib.rocks](https://contrib.rocks).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -51,7 +51,7 @@ const config = {
         // },
         items: [
           {
-            href: 'https://github.com/Italia-Open-Source/awesome-italia-opensource',
+            href: 'https://github.com/italia-opensource/awesome-italia-opensource',
             label: 'GitHub',
             position: 'left',
           },


### PR DESCRIPTION
Wrong repository name used on project.

Changed https://github.com/italia-open-source/awesome-italia-opensource to https://github.com/italia-opensource/awesome-italia-opensource