### PR TITLE
feat: adding kamaji

### DIFF
--- a/data/kamaji.json
+++ b/data/kamaji.json
@@ -1,0 +1,9 @@
+{
+	"name": "kamaji",
+	"repository_platform": "github",
+	"repository_url": "https://github.com/clastix/kamaji",
+	"site_url": "https://clastix.io/kamaji",
+	"type": "tool",
+	"license": " Apache-2.0 license",
+	"tags": ["kubernetes", "multi-tenant", "cluster", "kubernetes-cluster", "k8s", "managed-kubernetes", "multi-cluster", "kubernetes-multitenancy", "kubernetes-in-kubernetes", "virtual-cluster"]
+}

--- a/data/kamaji.json
+++ b/data/kamaji.json
@@ -4,6 +4,6 @@
 	"repository_url": "https://github.com/clastix/kamaji",
 	"site_url": "https://clastix.io/kamaji",
 	"type": "tool",
-	"license": " Apache-2.0 license",
+	"license": "Apache-2.0",
 	"tags": ["kubernetes", "multi-tenant", "cluster", "kubernetes-cluster", "k8s", "managed-kubernetes", "multi-cluster", "kubernetes-multitenancy", "kubernetes-in-kubernetes", "virtual-cluster"]
 }


### PR DESCRIPTION
Kamaji is a Kubernetes operator that allows to build and operate self-service Kubernetes at scale with a fraction of the operational burden.
Kamaji is developed by CLASTIX, an italian start-up based in Milan focused in developing tools for k8s.