### PR TITLE
Add dgc.json

### DIFF
--- a/data/dgc.json
+++ b/data/dgc.json
@@ -5,6 +5,7 @@
     "site_url": "https://docs.rs/dgc/latest/dgc/",
     "type": "library",
     "license": "MIT",
+    "description": "A parser and validator for the EU Digital Green Certificate (dgc) a.k.a. greenpass",
     "tags": [
       "rust", "green pass", "covid", "parser", "validator"
     ]

--- a/data/dgc.json
+++ b/data/dgc.json
@@ -1,0 +1,11 @@
+{
+    "name": "Dgc",
+    "repository_platform": "github",
+    "repository_url": "https://github.com/rust-italia/dgc",
+    "site_url": "https://docs.rs/dgc/latest/dgc/",
+    "type": "library",
+    "license": "MIT",
+    "tags": [
+      "rust", "green pass", "covid", "parser", "validator"
+    ]
+  }


### PR DESCRIPTION
Dgc is a parser and validator for the EU Digital Green Certificate (dgc) a.k.a. greenpass 📲✅

Made by the rust Italia open source group