### PR TITLE
fix: replace startups with innovative companies and fix broken link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -55,8 +55,8 @@ const config = {
             position: 'left',
             items: [
               {
-                href: 'https://italia-opensource.github.io/awesome-italia-startups',
-                label: 'Awesome Startups',
+                href: 'https://italia-opensource.github.io/awesome-italia-innovative-companies',
+                label: 'Innovative Companies',
               }
             ]
           },

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -56,7 +56,7 @@ export default function Home(): JSX.Element {
             </header>
             <section>
               <p>
-              The newsletter will be dedicated to keeping you updated on new open source projects, new startups in the Italian community and events around the country.
+              The newsletter will be dedicated to keeping you updated on new open source projects, new companies in the Italian community and events around the country.
               </p>
             </section>
             <footer>


### PR DESCRIPTION
The link to [awesome-italia-innovative-companies](https://github.com/italia-opensource/awesome-italia-innovative-companies) is broken since the rename in italia-opensource/awesome-italia-innovative-companies#5.