### PR TITLE
fix(opensource): spaces at the end of the name property generate a wrong link for README.md

### DIFF
--- a/awesome/opensource/data/make-js-component.json
+++ b/awesome/opensource/data/make-js-component.json
@@ -1,5 +1,5 @@
 {
-  "name": "Make Js Component  ",
+  "name": "Make Js Component",
   "repository_platform": "github",
   "repository_url": "https://github.com/Giuliano1993/make-js-component",
   "type": "package",


### PR DESCRIPTION
… README.md

## PR Checklist

- [X] I have read the [Contributing Guidelines on pull requests](https://github.com/italia-opensource/awesome-italia-opensource/blob/main/CONTRIBUTING.md#pull-requests).
- [X] I have read the [Code of conduct](https://github.com/italia-opensource/awesome-italia-opensource/blob/main/CODE_OF_CONDUCT.md).

**If this is an added new project**

- [ ] I created the "company-name.json" file in the awesome/companies/data folder and complied with the required fields
- [ ] I created the "project-name.json" file in the awesome/opensource/data folder and complied with the required fields
- [ ] I created the "communities-name.json" file in the awesome/communities/data folder and complied with the required fields
- [ ] I created the "digital-nomads-name.json" file in the awesome/digital-nomads/data folder and complied with the required fields
- [ ] The project you entered is still maintained and includes guidelines for use

**If this is related to an issue/PR**

- [ ] I documented and tested the code (issue #)
