### PR TITLE
feat(opensource): added GoccIA

### DIFF
--- a/awesome/opensource/data/goccia.json
+++ b/awesome/opensource/data/goccia.json
@@ -1,0 +1,21 @@
+{
+  "name": "GoccIA",
+  "type": "app",
+  "tags": [
+    "water-quality",
+    "acqua-potabile",
+    "civic-tech",
+    "italian",
+    "nextjs",
+    "supabase",
+    "typescript",
+    "tailwindcss",
+    "open-data",
+    "health"
+  ],
+  "description": "Strumento web gratuito e anonimo in italiano che assegna un punteggio 1-99 all'acqua del rubinetto a partire dai valori del referto. Motore deterministico basato sui limiti del D.Lgs. 18/2023 e sui range ideali WHO/EFSA.",
+  "site_url": "https://goccia.org",
+  "repository_platform": "github",
+  "repository_url": "https://github.com/tutor-sicurezza/goccia",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adding **GoccIA** — open-source Italian web tool that assigns a deterministic 1–99 score to tap-water analyses based on D.Lgs. 18/2023 legal limits and WHO/EFSA ideal ranges.

- Site: https://goccia.org
- Repo: https://github.com/tutor-sicurezza/goccia
- License: MIT
- Stack: Next.js 15, TypeScript, Supabase, Tailwind
- Anonymous, free, no login required. Italian-only UI.

Provider: 123Acqua (Labservice Analytica) — Italian water analysis lab.