### PR TITLE
feat(opensource): added Zornade Studio

### DIFF
--- a/awesome/opensource/data/zornade-studio.json
+++ b/awesome/opensource/data/zornade-studio.json
@@ -1,0 +1,19 @@
+{
+  "name": "Zornade Studio",
+  "repository_platform": "github",
+  "repository_url": "https://github.com/zornade/zornade-studio",
+  "site_url": "https://studio.zornade.com",
+  "type": "tool",
+  "description": "No-code editor to build choropleth, bivariate, cartogram and flow maps from Italian open data (OpenStreetMap, ISTAT, Eurostat, dati.gov.it) or your own CSV, publishable as embeddable maps.",
+  "license": "AGPL-3.0",
+  "tags": [
+    "react",
+    "typescript",
+    "maplibre",
+    "gis",
+    "data-visualization",
+    "choropleth",
+    "open-data",
+    "cartography"
+  ]
+}


### PR DESCRIPTION
Adds Zornade Studio, an AGPL-3.0 open-source no-code map editor (choropleth, bivariate, cartogram, flow maps) built with React/TypeScript and MapLibre GL, integrating OpenStreetMap, ISTAT, Eurostat and dati.gov.it data sources.

Repo: https://github.com/zornade/zornade-studio
Site: https://studio.zornade.com