### PR TITLE
feat(startups): added Zornade

### DIFF
--- a/awesome/startups/data/zornade.json
+++ b/awesome/startups/data/zornade.json
@@ -3,7 +3,7 @@
   "repository_organization_url": "https://www.github.com/zornade",
   "site_url": "https://zornade.com",
   "type": "B2B",
-  "market": "GIS & PropTech",
+  "market": "Software",
   "description": "Aggregates 15+ Italian public data sources (catasto, ISPRA hydrogeological risk, OMI prices, demographics) into a single per-parcel profile covering 85M cadastral parcels across 7,899 municipalities, with a free web platform, a REST API and an open-source no-code map editor (Zornade Studio).",
   "tags": [
     "gis",

--- a/awesome/startups/data/zornade.json
+++ b/awesome/startups/data/zornade.json
@@ -1,0 +1,18 @@
+{
+  "name": "Zornade",
+  "repository_organization_url": "https://www.github.com/zornade",
+  "site_url": "https://zornade.com",
+  "type": "B2B",
+  "market": "GIS & PropTech",
+  "description": "Aggregates 15+ Italian public data sources (catasto, ISPRA hydrogeological risk, OMI prices, demographics) into a single per-parcel profile covering 85M cadastral parcels across 7,899 municipalities, with a free web platform, a REST API and an open-source no-code map editor (Zornade Studio).",
+  "tags": [
+    "gis",
+    "proptech",
+    "opendata",
+    "cadastral",
+    "real-estate",
+    "python",
+    "typescript"
+  ],
+  "foundation_year": "2024"
+}


### PR DESCRIPTION
Adds Zornade, an Italian GIS/PropTech startup (founded 2024) that aggregates 15+ public data sources (catasto, ISPRA hydrogeological risk, OMI prices, ISTAT demographics) into a per-parcel profile covering 85M cadastral parcels across 7,899 municipalities. Free web platform + REST API, plus an open-source no-code map editor (Zornade Studio, submitted separately to the opensource list).

Site: https://zornade.com