### PR TITLE
feat(digital-nomads): updated Phuket resources

### DIFF
--- a/awesome/digital-nomads/data/phuket.json
+++ b/awesome/digital-nomads/data/phuket.json
@@ -18,7 +18,7 @@
   ],
   "resources": [
     "https://vitanellozaino.com/",
-    "https://kvartiry-phuket.com/ceny/"
+    "https://kvartiry-phuket.com/en/phuket-condo-prices/"
   ],
   "coworking": [
     "https://g.co/kgs/j36oVgX", "https://www.xyzlab.com/post/coworking-spaces-phuket", "https://www.starbucks.co.th/", "https://www.cafe-amazon.com/index.aspx?Lang=EN"

--- a/awesome/digital-nomads/data/phuket.json
+++ b/awesome/digital-nomads/data/phuket.json
@@ -17,7 +17,8 @@
     "Walk", "Taxi", "Other"
   ],
   "resources": [
-    "https://vitanellozaino.com/"
+    "https://vitanellozaino.com/",
+    "https://kvartiry-phuket.com/ceny/"
   ],
   "coworking": [
     "https://g.co/kgs/j36oVgX", "https://www.xyzlab.com/post/coworking-spaces-phuket", "https://www.starbucks.co.th/", "https://www.cafe-amazon.com/index.aspx?Lang=EN"


### PR DESCRIPTION
## What this updates

Adds one maintained residential-research resource to the existing Phuket digital-nomad page:

- [Phuket condo asking-price snapshot](https://kvartiry-phuket.com/en/phuket-condo-prices/)
- Dedicated English-language CC BY 4.0 research page with aggregate data, charts, CSV/JSON, methodology and limitations
- 391 exact-URL-deduplicated sale-listing observations from 19 April through 20 July 2026

This is intended as a bounded long-term housing/purchase reference for people considering an extended relocation to Phuket. It does **not** replace the page's daily-cost figure and does not claim rental costs, completed transactions, or current active inventory.

Affiliation disclosure: I am submitting this on behalf of Kvartiry Phuket, which publishes the linked resource. The publisher is a commercial property-discovery and lead-generation website; that relationship is disclosed on the research page so maintainers can evaluate the resource on its merits.

## Validation

- [x] I have read the contribution guidelines.
- [x] I have read the code of conduct.
- [x] Only `awesome/digital-nomads/data/phuket.json` is changed; generated README files are untouched.
- [x] `python scripts/check.py` passed on the original submission and the follow-up changes only the resource URL.
- [x] The English target is public, requires no account, and links to its methodology and downloadable data.

The "new project" checklist is not applicable because this updates the resources array of the existing Phuket entry.