### PR TITLE
feat(communities): added Web Developers Italia

### DIFF
--- a/awesome/communities/data/web-developers-italia.json
+++ b/awesome/communities/data/web-developers-italia.json
@@ -1,0 +1,9 @@
+{
+  "name": "Web Developers Italia",
+  "url": "https://t.me/webdevitalia",
+  "type": "Channel",
+  "platform": "Telegram",
+  "description": "Italian Telegram community for web developers: technical Q&A on frontend, backend and DevOps, career talk and job posts with mandatory salary range (RAL), moderated daily by an open source bot.",
+  "tags": ["webdev", "frontend", "backend", "devops", "career", "jobs"],
+  "events_type": ["Chat"]
+}


### PR DESCRIPTION
Adds **Web Developers Italia** (https://t.me/webdevitalia), an Italian Telegram community for web developers: technical Q&A on frontend/backend/DevOps, career discussions, and job posts with mandatory salary range. Actively moderated every day by an open source bot (https://github.com/web-developers-italia/telegram-bot). Entry follows scheme/communities.json.