### PR TITLE
feat(opensource): added Web Developers Italia Telegram Bot

### DIFF
--- a/awesome/opensource/data/web-developers-italia-telegram-bot.json
+++ b/awesome/opensource/data/web-developers-italia-telegram-bot.json
@@ -1,0 +1,10 @@
+{
+  "name": "Web Developers Italia Telegram Bot",
+  "repository_platform": "github",
+  "repository_url": "https://github.com/web-developers-italia/telegram-bot",
+  "site_url": "https://web-developers-italia.github.io/telegram-bot/",
+  "description": "Community-maintained moderation bot for the Web Developers Italia Telegram group: grammY commands and middleware written as Effect programs with typed errors, anti-spam and anti-flood guards, welcome flows, weekly digests and referral tracking on Firebase.",
+  "type": "tool",
+  "license": "MIT",
+  "tags": ["telegram", "bot", "grammy", "effect", "typescript", "firebase"]
+}


### PR DESCRIPTION
Adds the **Web Developers Italia Telegram Bot** (https://github.com/web-developers-italia/telegram-bot), the MIT-licensed bot that runs the Web Developers Italia community group: grammY + Effect (typed errors, injectable services), anti-spam/anti-flood moderation, welcome flows, weekly digests and referral tracking on Firebase Functions + Firestore. Maintained by the community with contribution docs and TDD test suite. Entry follows scheme/opensources.json.