### PR TITLE
feat(opensource): added CommentHide

### DIFF
--- a/awesome/opensource/data/commenthide.json
+++ b/awesome/opensource/data/commenthide.json
@@ -1,0 +1,18 @@
+{
+  "name": "CommentHide",
+  "type": "tool",
+  "tags": [
+    "typescript",
+    "cloudflare",
+    "cloudflare-workers",
+    "facebook",
+    "moderation",
+    "self-hosted",
+    "marketing"
+  ],
+  "description": "Self-hosted Facebook comment moderation. Automatically hides spam, scam and link-drop comments on Meta Page posts through the Graph API, with a rule engine, a dry-run mode and a full audit trail.",
+  "site_url": null,
+  "repository_platform": "github",
+  "repository_url": "https://github.com/Hiberius/commenthide-facebook-comment-moderation",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds **CommentHide** to `awesome/opensource`.

[CommentHide](https://github.com/Hiberius/commenthide-facebook-comment-moderation) is a self-hosted Facebook comment moderation tool that runs as a single Cloudflare Worker in the operator's own account. A cron trigger checks watched Page posts every minute and hides spam, scam and link-drop comments through the official Meta Graph API — with a rule engine, a dry-run mode that records verdicts without touching Facebook, and a full audit trail with one-click undo.

Built and maintained in Italy 🇮🇹 by [@Hiberius](https://github.com/Hiberius).

- MIT licensed
- TypeScript strict, 299 tests, CI green
- Full documentation and a 60-second quickstart in the README
- Ships an offline mock of the Graph API so it can be run and developed without a Facebook App

Only the manual fields are filled in; the `autogenerated` block is left to your pipeline.